### PR TITLE
[IAC-1677] Replace gofmt with goimports

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,6 +49,8 @@ jobs:
       - run:
           command: |
             pip install pre-commit
+            go get golang.org/x/tools/cmd/goimports
+            export GOPATH=~/go/bin && export PATH=$PATH:$GOPATH 
             pre-commit install
             pre-commit run --all-files
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,4 +3,4 @@ repos:
     rev:  v0.1.10
     hooks:
       - id: terraform-fmt
-      - id: gofmt
+      - id: goimports


### PR DESCRIPTION
Replace gofmt with goimports in the pre-commit configuration. Note: This PR was opened using git-xargs.