### PR TITLE
[CORE-669] Add permission to create ingress

### DIFF
--- a/modules/namespace-roles/main.tf
+++ b/modules/namespace-roles/main.tf
@@ -117,6 +117,7 @@ resource "kubernetes_role" "rbac_helm_resource_access" {
       "extensions",
       "apps",
       "rbac.authorization.k8s.io", # We include RBAC here because many helm charts create RBAC roles to minimize pod access.
+      "networking.k8s.io",         # Grants access to create Ingress objects.
     ]
 
     resources = ["*"]


### PR DESCRIPTION
## Description

Adds a permission that's required for creating ingresses. The reason we needed this is because the K8s deployer that's used in dogfood accounts will `apply` both Aperture and mission-control k8s services. Those services create ingresses so if the deployer doesn't have this permission then it can't function. Note: This was previously not required in older versions of EKS but is now needed.

For reference permissions for `ingress` used to be granted via the `extensions` API and now are in the `networking.k8s.io`.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Added permission: `networking.k8s.io` to the `[NAME]-helm-resource-access` role that gets created in the EKS cluster.

### Migration Guide

This is not a breaking change. There's nothing to migrate.